### PR TITLE
fix: wrap search input and button with <form> element

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -19,7 +19,7 @@ function SearchBar({ onSearch }) {
  }
 
  return (
-  <section className='cont cont--align-center cont--border cont--flex-column cont--padding'>
+  <form className='cont cont--align-center cont--border cont--flex-column cont--padding'>
    <div className='cont cont--flex-column cont--search-input'>
     <label className='subheading subheading--bold-underline' htmlFor='cityName'>
      Enter an Australian city:
@@ -38,7 +38,7 @@ function SearchBar({ onSearch }) {
    <button className='button' onClick={clickHandler}>
     Search
    </button>
-  </section>
+  </form>
  )
 }
 


### PR DESCRIPTION
**Description/Changes**
Add `<form>` element to enable user to press enter key when searching for a city

(Fixes #21)